### PR TITLE
[diary] Summary의 comment 부분 stateless 컴포넌트 (Comment.js)로 분리

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-dropzone": "^4.2.1",
+    "react-easy-emoji": "^1.1.0",
     "react-helmet": "^5.2.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",

--- a/frontend/src/Root.js
+++ b/frontend/src/Root.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 import {
   BrowserRouter,
   Route,

--- a/frontend/src/actions/weight.js
+++ b/frontend/src/actions/weight.js
@@ -131,7 +131,7 @@ export const getAllWeightFromDB = () => {
         let chartData = []
         data.allDayLog.map(aDay => {
           if (aDay.day_log_kg) {
-            chartData.push({
+            return chartData.push({
               current: aDay.day_log_kg,
               date: aDay.day_log_diary_date
                 .substr(5, 5)

--- a/frontend/src/components/Navigation/index.js
+++ b/frontend/src/components/Navigation/index.js
@@ -30,19 +30,6 @@ class Navigation extends Component {
     )
   }
 
-  // componentWillReceiveProps(nextProps) {
-  //   const { date, day } = nextProps
-  //   if (
-  //     this.props.dateState !== nextProps.dateState
-  //   ) {
-  //     this.setState({
-  //       date: nextProps.dateState,
-  //       day: nextProps.dayState,
-  //     })
-
-  //   }
-  // }
-
   fetchData = () => {
     setTimeout(() => {
       this.setState({
@@ -68,11 +55,6 @@ class Navigation extends Component {
 Navigation.defaultProps = {
   color: '#16325c',
 }
-
-const mapStateToProps = state => ({
-  dateState: state.today.date,
-  dayState: state.today.day,
-})
 
 const mapDispatchToProps = dispatch => ({
   saveUserInfo: () => dispatch(getUserInfo()),

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,3 +1,4 @@
-export const API_HOST = 'https://api.downmix.net'
+export const API_HOST =
+  'https://devapi.downmix.net'
 
 export default API_HOST

--- a/frontend/src/helper/emoji.js
+++ b/frontend/src/helper/emoji.js
@@ -1,0 +1,10 @@
+import emoji from 'react-easy-emoji'
+
+// 트위터 이모지팩 CDN 참고 예시: https://twemoji.maxcdn.com/2/test/preview.html
+export const svgEmoji = input => {
+  return emoji(input, {
+    baseUrl: 'https://twemoji.maxcdn.com/2/svg/',
+    ext: '.svg',
+    size: '',
+  })
+}

--- a/frontend/src/pages/DiaryPage/DiaryFood/FoodList.js
+++ b/frontend/src/pages/DiaryPage/DiaryFood/FoodList.js
@@ -50,7 +50,7 @@ class FoodList extends React.Component {
     return (
       <div style={{ display: 'flex' }}>
         {foodresult.map((card, i) => {
-          const nuturitionInfo = [
+          const nutritionInfo = [
             {
               name: '탄',
               value: card.food_carb,
@@ -114,7 +114,7 @@ class FoodList extends React.Component {
                 </p>
 
                 <div className="diary-food-meal-list-card-nutritions">
-                  {nuturitionInfo.map(item => (
+                  {nutritionInfo.map(item => (
                     <span className="diary-food-meal-list-card-nutrition-wrapper">
                       <span className="diary-food-meal-list-card-nutrition-title">
                         {item.name}

--- a/frontend/src/pages/DiaryPage/DiarySubNav.js
+++ b/frontend/src/pages/DiaryPage/DiarySubNav.js
@@ -5,7 +5,6 @@ import {
   Segment,
   Icon,
   Input,
-  Button,
 } from 'semantic-ui-react'
 import {
   calorieGoal,
@@ -14,7 +13,6 @@ import {
 } from './StyledDiaryCommon'
 import './Diary.css'
 // 리덕스 액션생성자
-import { getUserInfo } from '../../actions/auth.js'
 import {
   getGoalKcal,
   postGoalKcal,
@@ -30,10 +28,7 @@ import { getCommentFromDB } from '../../actions/review'
 import { getArticleFromDB } from '../../actions/review'
 
 // helper: 오늘 날짜
-import {
-  dateDotToDateType,
-  dateStringForApiQuery,
-} from '../../helper/date'
+import { dateStringForApiQuery } from '../../helper/date'
 
 class DiarySubNav extends Component {
   constructor(props) {
@@ -47,14 +42,12 @@ class DiarySubNav extends Component {
   }
 
   componentWillMount() {
-    const { date, day } = this.state
     this.props.getGoalKcal(
-      dateStringForApiQuery(date),
+      dateStringForApiQuery(this.state.date),
     )
   }
 
   componentWillReceiveProps(nextProps) {
-    const { date, day } = nextProps
     if (
       this.props.dateState !== nextProps.dateState
     ) {

--- a/frontend/src/pages/DiaryPage/DiarySummary/Comment.js
+++ b/frontend/src/pages/DiaryPage/DiarySummary/Comment.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react'
+import { svgEmoji } from '../../../helper/emoji'
+// 스타일링
+import { Segment } from 'semantic-ui-react'
+import { comment } from './StyledDiarySummary'
+
+const Comment = props => {
+  const { restKcal, goalKcal, eatKcal } = props
+
+  return restKcal < 0 ? (
+    // 목표칼로리+운동칼로리 < 섭취칼로리
+    <Segment style={comment}>
+      <p>
+        {restKcal * -1}kcal 초과했어요!{svgEmoji('😵')}
+        <br />괜찮아요! 내일의 목표칼로리를<br /> 낮추실 수 있습니다!{svgEmoji('😊')}
+      </p>
+    </Segment>
+  ) : restKcal ? (
+    // 목표칼로리+운동칼로리 >= 섭취칼로리
+    <Segment style={comment}>
+      {/* 목표 칼로리의 2/3 이상 섭취 하였는 지 확인(운동칼로리 제외) */}
+      {goalKcal / eatKcal < 1.5 ? (
+        <p>
+          {restKcal}kcal 남았습니다! <br />
+          오늘처럼만 한다면 30일 후에는{' '}
+          <span
+            style={{
+              fontWeight: '400',
+            }}
+          >
+            {/* 1kg = 7700kcal */}
+            {Math.round(restKcal * 30 / 7700)}kg
+          </span>{' '}
+          감량하실거에요!{svgEmoji('😍')}
+        </p>
+      ) : (
+        //  사용자가 2/3 미만으로 섭취한 경우
+        <p>
+          무리한 절식은 건강을 해칩니다.
+          <br /> 더 잘 챙겨드세요{svgEmoji('😭')}{' '}
+        </p>
+      )}
+    </Segment>
+  ) : (
+    // 식사 기록이 없는 경우
+    <Segment style={comment}>
+      <p>
+        아직 오늘의 식사를 <br /> 기록하지 않으셨어요!
+      </p>
+    </Segment>
+  )
+}
+
+export default Comment

--- a/frontend/src/pages/DiaryPage/DiarySummary/SectionHeader.js
+++ b/frontend/src/pages/DiaryPage/DiarySummary/SectionHeader.js
@@ -3,9 +3,6 @@ import { Header } from 'semantic-ui-react'
 import { subheader } from './StyledDiarySummary'
 
 class SectionHeader extends Component {
-  constructor(props) {
-    super(props)
-  }
   render() {
     const {
       subtitle,

--- a/frontend/src/pages/DiaryPage/DiarySummary/SummaryListItem.js
+++ b/frontend/src/pages/DiaryPage/DiarySummary/SummaryListItem.js
@@ -8,9 +8,6 @@ import {
 } from './StyledDiarySummary'
 
 class SummaryListItem extends Component {
-  constructor(props) {
-    super(props)
-  }
   render() {
     const { label, kcal } = this.props
     return (

--- a/frontend/src/pages/DiaryPage/DiarySummary/index.js
+++ b/frontend/src/pages/DiaryPage/DiarySummary/index.js
@@ -1,18 +1,14 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 // 스타일링
-import {
-  Segment,
-  Header,
-  List,
-  Message,
-} from 'semantic-ui-react'
+import { Segment, List } from 'semantic-ui-react'
 import * as Style from './StyledDiarySummary'
 
 // 컴포넌트
 import SectionHeader from './SectionHeader'
 import SummaryListItem from './SummaryListItem'
 import DiarySocialBtns from './DiarySocialBtns'
+import Comment from './Comment'
 import SummaryPieChart from '../../../components/Charts/SummaryPieChart'
 
 // API 통신용 date형식 리턴하는 함수: YYYYMMDD
@@ -25,10 +21,6 @@ import {
 import { getGoalKcal } from '../../../actions/diaryKcal' // 하루 단위 목표 칼로리 get
 
 class DiarySummary extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   componentWillMount() {
     const {
       getFoodSummaryFromDB,
@@ -105,28 +97,11 @@ class DiarySummary extends Component {
 
           {/* comment 시작 */}
           <SectionHeader subtitle="COMMENT" />
-
-          {restCalorie < 0 ? (
-            <Segment style={Style.comment}>
-              <span>
-                목표칼로리를 초과하였어요!<br />운동을 더 하셔야겠어요!
-              </span>
-            </Segment>
-          ) : restCalorie ? (
-            <Segment style={Style.comment}>
-              <span>
-                {restCalorie}kcal 남았어요! <br /> 너무
-                잘하고 있어요!
-              </span>
-            </Segment>
-          ) : (
-            <Segment style={Style.comment} t>
-              <span>
-                아직 오늘의 식사를 <br /> 기록하지 않으셨어요!
-              </span>
-            </Segment>
-          )}
-
+          <Comment
+            restKcal={restCalorie}
+            goalKcal={goalCalorie}
+            eatKcal={eatKcal}
+          />
           {/* comment 끝 */}
 
           {/* 파이 차트 시작 */}

--- a/frontend/src/pages/ReportPage/ReportSubNav.js
+++ b/frontend/src/pages/ReportPage/ReportSubNav.js
@@ -27,7 +27,6 @@ class ReportSubNav extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { date, day } = nextProps
     if (
       this.props.lastDateState !==
       nextProps.lastDateState

--- a/frontend/src/pages/ReportPage/index.js
+++ b/frontend/src/pages/ReportPage/index.js
@@ -1,20 +1,14 @@
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 import './Report.css'
 
 // 컴포넌트
 import Navigation from '../../components/Navigation'
-import Footer from '../../components/Footer'
 import ReportSubNav from './ReportSubNav'
 import ReportContainer from './ReportContainer'
-import ComponentLoader from '../../components/Loader/ComponentLoader'
+import Footer from '../../components/Footer'
 
 class ReportPage extends Component {
   render() {
-    // if (this.props.isLoading) {
-    //   return <ComponentLoader />
-    // }
-
     return (
       <div className="report">
         <Navigation />
@@ -27,13 +21,4 @@ class ReportPage extends Component {
   }
 }
 
-const mapStateToProps = state => ({
-  // isLoading:
-  //   state.caloriesChart.isLoading ||
-  //   state.nutritionChart.isLoading ||
-  //   state.calorySummary.isLoading ||
-  //   state.nutritionSummary.isLoading,
-})
-export default connect(mapStateToProps, null)(
-  ReportPage,
-)
+export default ReportPage

--- a/frontend/src/reducers/appReducer/date.js
+++ b/frontend/src/reducers/appReducer/date.js
@@ -1,9 +1,5 @@
 // helper: 오늘 날짜
-import {
-  getDateNDaysBefore,
-  getDateNDaysAfter,
-  setDay,
-} from '../../helper/date'
+import { setDay } from '../../helper/date'
 
 const TODAY_INITIAL_STATE = {
   day: null,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4326,6 +4326,10 @@ lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
 
+lodash.assign@^4.0.8:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
 lodash.assignin@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
@@ -4357,6 +4361,10 @@ lodash.flatten@^4.2.0:
 lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
 
 lodash.map@^4.4.0:
   version "4.6.0"
@@ -5688,6 +5696,13 @@ react-dropzone@^4.2.1:
     attr-accept "^1.0.3"
     prop-types "^15.5.7"
 
+react-easy-emoji@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-easy-emoji/-/react-easy-emoji-1.1.0.tgz#999f221d1936e85419d2673a55fbe28c20099871"
+  dependencies:
+    lodash.assign "^4.0.8"
+    string-replace-to-array "^1.0.1"
+
 react-error-overlay@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-2.0.2.tgz#967b091962b17f5aeb4a60b1311b1736e1b6533d"
@@ -6578,6 +6593,14 @@ string-length@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
   dependencies:
     strip-ansi "^3.0.0"
+
+string-replace-to-array@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string-replace-to-array/-/string-replace-to-array-1.0.3.tgz#c93eba999a5ee24d731aebbaf5aba36b5f18f7bf"
+  dependencies:
+    invariant "^2.2.1"
+    lodash.flatten "^4.2.0"
+    lodash.isstring "^4.0.1"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 추가된 파일
- helper/emoji.js
- pages/DiaryPage/DiarySummary/Comment.js

<br>

## 추가된 의존모듈
- react-easy-emoji

<br>

## 주요 변경 내용
- api 호스트 도메인 api.downmix.net (배포용) -> devapi.downmix.net (개발용)으로 변경
- Summary의 comment 뷰를 다르게 렌더링하는 경우의 수 추가 & 콘텐츠에 이모지 사용
  - 1) 목표칼로리를 초과한 경우 (조건문 동일, 코멘트만 수정됨) -> 다음날 목표칼로리 수정을 권장하는 코멘트
  - 2) 목표칼로리를 초과하지 않은 경우 (기존과 동일)
    - b-1) 섭취 칼로리가 목표 칼로리의 2/3 이상인 경우 (추가됨) -> 칭찬 코멘트
    - b-2) 섭취 칼로리가 목표 칼로리의 2/3 미만인 경우 (추가됨) -> 추가 섭취를 권장하는 코멘트 
- stateless component로 분리 -> Comment.js
- 기타 코드 정리(사용 되지 않는 변수, 컴포넌트, 불필요한 주석 등)
