### PR TITLE
사용자 정보 팝업에서 d-day 고정값(10일) -> 실제 계산 값으로 표시되도록 수정

### DIFF
--- a/frontend/src/components/Navigation/RightMenu/UserInfoPopup.js
+++ b/frontend/src/components/Navigation/RightMenu/UserInfoPopup.js
@@ -12,6 +12,8 @@ import '../Navigation.css'
 import * as Style from '../StyledNavigation'
 // 리덕스 액션
 import { logOut } from '../../../actions/auth'
+// date heler
+import { calculateDday } from '../../../helper/date'
 
 class UserInfo extends Component {
   state = { open: false }
@@ -28,6 +30,8 @@ class UserInfo extends Component {
   render() {
     const { open, size } = this.state
     const { userInfo } = this.props
+    const dateTime = new Date()
+
     return (
       <Grid style={Style.PopWrap}>
         <Grid.Row style={Style.row_1}>
@@ -58,7 +62,11 @@ class UserInfo extends Component {
         <Grid.Row style={Style.row_2}>
           <Segment style={Style.row_2_segment}>
             <p style={Style.d_day}>
-              오늘은 10일차 입니다.
+              오늘은{' '}
+              {calculateDday(
+                userInfo.userJoinDate,
+                dateTime,
+              )}일차 입니다.
             </p>
             <div style={Style.goalWrap}>
               목표체중까지

--- a/frontend/src/helper/date.js
+++ b/frontend/src/helper/date.js
@@ -128,3 +128,15 @@ export const getWeekArray = dateTypeStartDate => {
   }
   return dateArray
 }
+
+// d-day 구하는 함수
+export const calculateDday = (
+  startDate, // 시작 날짜, Date 타입
+  targetDate, // D-day 구하려는 날짜, Date 타입
+) => {
+  return Math.round(
+    (targetDate.getTime() - startDate.getTime()) /
+      (1000 * 60 * 60 * 24) +
+      1,
+  )
+}

--- a/frontend/src/reducers/authReducer/auth.js
+++ b/frontend/src/reducers/authReducer/auth.js
@@ -46,7 +46,7 @@ const authReducer = (
           action.payload.user.member_birth,
         userJoinDate: new Date(
           action.payload.user.member_join_date,
-        ).toLocaleDateString(),
+        ),
         userDefaultKcal: action.payload
           .default_kcal
           ? action.payload.default_kcal


### PR DESCRIPTION
1. d-day 계산하는 helper 함수 추가
```js
//helper/date.js
// d-day 구하는 함수
export const calculateDday = (
  startDate, // 시작 날짜, Date 타입
  targetDate, // D-day 구하려는 날짜, Date 타입
) => {
  return Math.round(
    (targetDate.getTime() - startDate.getTime()) /
      (1000 * 60 * 60 * 24) +
      1,
  )
}
```

2. 계산된 d-day로 렌더되도록 변경

```js
// 변경 전 UserInfoPopup.js
오늘은 10일차 입니다.
```

```js
// 변경 후 UserInfoPopup.js
오늘은{' '}
      {calculateDday(
        userInfo.userJoinDate,
        dateTime,
      )}일차 입니다.
```
